### PR TITLE
Fix interface casting and return value issue in EditSession and LanguageBar components

### DIFF
--- a/src/Edit/EditSession.cpp
+++ b/src/Edit/EditSession.cpp
@@ -47,7 +47,7 @@ STDAPI CEditSessionBase::QueryInterface(REFIID riid, _Outptr_ void **ppvObj)
 
     if (IsEqualIID(riid, IID_IUnknown) || IsEqualIID(riid, IID_ITfEditSession))
     {
-        *ppvObj = (ITfLangBarItemButton *)this;
+        *ppvObj = (ITfEditSession *)this;
     }
 
     if (*ppvObj)

--- a/src/LanguageBar/LanguageBar.cpp
+++ b/src/LanguageBar/LanguageBar.cpp
@@ -285,7 +285,7 @@ STDAPI CLangBarItemButton::GetStatus(_Out_ DWORD *pdwStatus)
 {
     if (pdwStatus == nullptr)
     {
-        E_INVALIDARG;
+        return E_INVALIDARG;
     }
 
     *pdwStatus = _status;


### PR DESCRIPTION

This PR fixes two minor but critical issues in the `EditSession` and `LanguageBar` modules.

1. EditSession.cpp:
   - Previously, the object was cast to `ITfLangBarItemButton`, which is incorrect when handling `IID_ITfEditSession`. Now it is properly cast to `ITfEditSession`.

2. LanguageBar.cpp:
   - Added the missing `return` statement.

